### PR TITLE
Use the --save flag when setting wallpaper with Nitrogen

### DIFF
--- a/src/vnr-window.c
+++ b/src/vnr-window.c
@@ -1428,7 +1428,7 @@ vnr_set_wallpaper(GtkAction *action, VnrWindow *win)
 				break;
 			case VNR_PREFS_DESKTOP_NITROGEN:
 				execlp("nitrogen", "nitrogen", 
-						"--set-zoom-fill",
+						"--set-zoom-fill", "--save",
 						VNR_FILE(win->file_list->data)->path, 
 						NULL);
 				break;


### PR DESCRIPTION
This flag will save the set wallpaper to Nitrogen's config file so that
it can be set again on future logins.
