### PR TITLE
Add option to hide the scrollbars.

### DIFF
--- a/src/uni-scroll-win.c
+++ b/src/uni-scroll-win.c
@@ -84,38 +84,28 @@ G_DEFINE_TYPE (UniScrollWin, uni_scroll_win, GTK_TYPE_TABLE);
 /***** Static stuff ******************************************/
 /*************************************************************/
 static void
-uni_scroll_win_adjustment_changed (GtkAdjustment * adj, UniScrollWin * window)
+uni_scroll_win_show_scrollbar (UniScrollWin * window, gboolean show)
 {
-    GtkAdjustment *hadj, *vadj;
-    hadj = gtk_range_get_adjustment (GTK_RANGE (window->hscroll));
-    vadj = gtk_range_get_adjustment (GTK_RANGE (window->vscroll));
-
-    /* We compare with the allocation size for the window instead of
-       hadj->page_size and vadj->page_size. If the scrollbars are
-       shown the views size is about 15 pixels shorter and thinner,
-       which makes the page sizes inaccurate. The scroll windows
-       allocation, on the other hand, always gives the correct number
-       of pixels that COULD be shown if the scrollbars weren't
-       there.
-     */
-    int width = GTK_WIDGET (window)->allocation.width;
-    int height = GTK_WIDGET (window)->allocation.height;
-
-    gboolean hide_hscr = (hadj->upper <= width);
-    gboolean hide_vscr = (vadj->upper <= height);
-
-    if (hide_hscr && hide_vscr)
-    {
-        gtk_widget_hide (window->vscroll);
-        gtk_widget_hide (window->hscroll);
-        gtk_widget_hide (window->nav_box);
-    }
-    else
+    if (show)
     {
         gtk_widget_show_now (window->vscroll);
         gtk_widget_show_now (window->hscroll);
         gtk_widget_show_now (window->nav_box);
     }
+    else
+    {
+        gtk_widget_hide (window->vscroll);
+        gtk_widget_hide (window->hscroll);
+        gtk_widget_hide (window->nav_box);
+    }
+}
+
+
+static void
+uni_scroll_win_adjustment_changed (GtkAdjustment * adj, UniScrollWin * window)
+{
+    uni_scroll_win_show_scrollbar (window,
+        window->show_scrollbar && !uni_scroll_win_image_fits (window));
 }
 
 static void
@@ -206,6 +196,7 @@ uni_scroll_win_init (UniScrollWin * window)
     window->vscroll = NULL;
     window->nav_box = NULL;
     window->nav = NULL;
+    window->show_scrollbar = FALSE;
 
     // Setup the navigator button.
     window->nav_button =
@@ -295,4 +286,49 @@ uni_scroll_win_new (UniImageView * view)
                                   "view", view,
                                   NULL);
     return GTK_WIDGET (data);
+}
+
+
+/**
+ * uni_scroll_win_image_fits:
+ * @window: the #UniScrollWin to inspect.
+ * @returns: A boolean indicating if the image fits in the window
+ *
+ * Check if the current image fits in the window without the need to scoll.
+ * The check is performed as if scrollbars are not visible.
+ **/
+gboolean
+uni_scroll_win_image_fits (UniScrollWin * window)
+{
+    GtkAdjustment *hadj, *vadj;
+    hadj = gtk_range_get_adjustment (GTK_RANGE (window->hscroll));
+    vadj = gtk_range_get_adjustment (GTK_RANGE (window->vscroll));
+
+    /* We compare with the allocation size for the window instead of
+       hadj->page_size and vadj->page_size. If the scrollbars are
+       shown the views size is about 15 pixels shorter and thinner,
+       which makes the page sizes inaccurate. The scroll windows
+       allocation, on the other hand, always gives the correct number
+       of pixels that COULD be shown if the scrollbars weren't
+       there.
+     */
+    int width = GTK_WIDGET (window)->allocation.width;
+    int height = GTK_WIDGET (window)->allocation.height;
+
+    return hadj->upper <= width && vadj->upper <= height;
+}
+
+/**
+ * uni_scroll_win_set_show_scrollbar:
+ * @window: the #UniScrollWin to adjust.
+ *
+ * Show or hide the scrollbar.
+ * The scrollbar will only be shown if the image doesn't fit in the window.
+ **/
+void
+uni_scroll_win_set_show_scrollbar (UniScrollWin * window, gboolean show)
+{
+    window->show_scrollbar = show;
+    uni_scroll_win_show_scrollbar (window,
+        window->show_scrollbar && !uni_scroll_win_image_fits (window));
 }

--- a/src/uni-scroll-win.h
+++ b/src/uni-scroll-win.h
@@ -56,6 +56,8 @@ struct _UniScrollWin {
 
     /* The normal and the highlighted nav_button pixbuf. */
     GdkPixbuf *nav_button;
+
+    gboolean show_scrollbar;
 };
 
 struct _UniScrollWinClass {
@@ -66,6 +68,9 @@ GType       uni_scroll_win_get_type (void) G_GNUC_CONST;
 
 /* Constructors */
 GtkWidget*   uni_scroll_win_new     (UniImageView * view);
+
+gboolean uni_scroll_win_image_fits         (UniScrollWin * window);
+void     uni_scroll_win_set_show_scrollbar (UniScrollWin * window, gboolean show);
 
 G_END_DECLS
 #endif /* __UNI_SCROLL_WIN_H__ */

--- a/src/vnr-prefs.c
+++ b/src/vnr-prefs.c
@@ -167,6 +167,7 @@ vnr_prefs_set_default(VnrPrefs *prefs)
     prefs->reload_on_save = FALSE;
     prefs->show_menu_bar = FALSE;
     prefs->show_toolbar = TRUE;
+    prefs->show_scrollbar = TRUE;
     prefs->start_maximized = FALSE;
     prefs->start_slideshow = FALSE;
     prefs->start_fullscreen = FALSE;
@@ -370,6 +371,7 @@ vnr_prefs_load (VnrPrefs *prefs)
     prefs->reload_on_save = g_key_file_get_boolean (conf, "prefs", "reload-on-save", &error);
     prefs->show_menu_bar = g_key_file_get_boolean (conf, "prefs", "show-menu-bar", &error);
     prefs->show_toolbar = g_key_file_get_boolean (conf, "prefs", "show-toolbar", &error);
+    prefs->show_scrollbar = g_key_file_get_boolean (conf, "prefs", "show-scrollbar", &error);
     prefs->start_maximized = g_key_file_get_boolean (conf, "prefs", "start-maximized", &error);
     prefs->slideshow_timeout = g_key_file_get_integer (conf, "prefs", "slideshow-timeout", &error);
     prefs->auto_resize = g_key_file_get_boolean (conf, "prefs", "auto-resize", &error);
@@ -461,6 +463,7 @@ vnr_prefs_save (VnrPrefs *prefs)
     g_key_file_set_boolean (conf, "prefs", "reload-on-save", prefs->reload_on_save);
     g_key_file_set_boolean (conf, "prefs", "show-menu-bar", prefs->show_menu_bar);
     g_key_file_set_boolean (conf, "prefs", "show-toolbar", prefs->show_toolbar);
+    g_key_file_set_boolean (conf, "prefs", "show-scrollbar", prefs->show_scrollbar);
     g_key_file_set_boolean (conf, "prefs", "start-maximized", prefs->start_maximized);
     g_key_file_set_integer (conf, "prefs", "slideshow-timeout", prefs->slideshow_timeout);
     g_key_file_set_boolean (conf, "prefs", "auto-resize", prefs->auto_resize);
@@ -508,6 +511,16 @@ vnr_prefs_set_show_toolbar (VnrPrefs *prefs, gboolean show_toolbar)
     if(prefs->show_toolbar != show_toolbar)
     {
         prefs->show_toolbar = show_toolbar;
+        vnr_prefs_save(prefs);
+    }
+}
+
+void
+vnr_prefs_set_show_scrollbar (VnrPrefs *prefs, gboolean show_scrollbar)
+{
+    if(prefs->show_scrollbar != show_scrollbar)
+    {
+        prefs->show_scrollbar = show_scrollbar;
         vnr_prefs_save(prefs);
     }
 }

--- a/src/vnr-prefs.h
+++ b/src/vnr-prefs.h
@@ -98,6 +98,7 @@ struct _VnrPrefs {
     gboolean reload_on_save;
     gboolean show_menu_bar;
     gboolean show_toolbar;
+    gboolean show_scrollbar;
     gboolean start_maximized;
     gboolean start_slideshow;
     gboolean start_fullscreen;
@@ -121,8 +122,9 @@ GType     vnr_prefs_get_type (void) G_GNUC_CONST;
 GObject*  vnr_prefs_new (GtkWidget *window);
 void      vnr_prefs_show_dialog (VnrPrefs *prefs);
 void      vnr_prefs_set_slideshow_timeout   (VnrPrefs *prefs, int value);
-void      vnr_prefs_set_show_toolbar    (VnrPrefs *prefs, gboolean show_toolbar);
 void      vnr_prefs_set_show_menu_bar   (VnrPrefs *prefs, gboolean show_menu_bar);
+void      vnr_prefs_set_show_toolbar    (VnrPrefs *prefs, gboolean show_toolbar);
+void      vnr_prefs_set_show_scrollbar    (VnrPrefs *prefs, gboolean show_scollbar);
 gboolean  vnr_prefs_save (VnrPrefs *prefs);
 
 G_END_DECLS

--- a/src/vnr-window.c
+++ b/src/vnr-window.c
@@ -82,6 +82,7 @@ const gchar *ui_definition = "<ui>"
     "<menu action=\"View\">"
       "<menuitem action=\"ViewMenuBar\"/>"
       "<menuitem action=\"ViewToolbar\"/>"
+      "<menuitem action=\"ViewScrollbar\"/>"
       "<separator/>"
       "<menuitem action=\"ViewZoomIn\"/>"
       "<menuitem action=\"ViewZoomOut\"/>"
@@ -137,6 +138,7 @@ const gchar *ui_definition = "<ui>"
       "<separator/>"
       "<menuitem action=\"ViewMenuBar\"/>"
       "<menuitem action=\"ViewToolbar\"/>"
+      "<menuitem action=\"ViewScrollbar\"/>"
       "<menuitem name=\"Fullscreen\" action=\"ViewFullscreen\"/>"
       "<menuitem name=\"Slideshow\" action=\"ViewSlideshow\"/>"
       "<separator/>"
@@ -187,6 +189,7 @@ const gchar *ui_definition = "<ui>"
     "<separator/>"
     "<menuitem name=\"MenuBar\" action=\"ViewMenuBar\"/>"
     "<menuitem name=\"Toolbar\" action=\"ViewToolbar\"/>"
+    "<menuitem name=\"Scrollbar\" action=\"ViewScrollbar\"/>"
     "<menuitem name=\"Fullscreen\" action=\"ViewFullscreen\"/>"
     "<separator/>"
     "<menuitem action=\"FileProperties\"/>"
@@ -489,16 +492,6 @@ get_fs_controls(VnrWindow *window)
 
     gtk_widget_show_all (window->fs_controls);
     return window->fs_controls;
-}
-
-static gboolean
-scrollbars_visible (VnrWindow *window)
-{
-    if (!gtk_widget_get_visible (GTK_WIDGET (UNI_SCROLL_WIN(window->scroll_view)->hscroll)) &&
-        !gtk_widget_get_visible (GTK_WIDGET (UNI_SCROLL_WIN(window->scroll_view)->vscroll)))
-        return FALSE;
-
-    return TRUE;
 }
 
 static void
@@ -1504,6 +1497,16 @@ vnr_window_cmd_toolbar (GtkAction *action, VnrWindow *window)
 }
 
 static void
+vnr_window_cmd_scrollbar (GtkAction *action, VnrWindow *window)
+{
+    gboolean show;
+
+    show = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+    vnr_prefs_set_show_scrollbar (window->prefs, show);
+    uni_scroll_win_set_show_scrollbar (UNI_SCROLL_WIN (window->scroll_view), show);
+}
+
+static void
 vnr_window_cmd_slideshow (GtkAction *action, VnrWindow *window)
 {
     if(!window->slideshow)
@@ -1849,6 +1852,9 @@ static const GtkToggleActionEntry toggle_entries_window[] = {
     { "ViewToolbar", NULL, N_("Toolbar"), NULL,
       N_("Show Toolbar"),
       G_CALLBACK (vnr_window_cmd_toolbar) },
+    { "ViewScrollbar", NULL, N_("Scrollbar"), NULL,
+      N_("Show Scrollbar"),
+      G_CALLBACK (vnr_window_cmd_scrollbar) },
 };
 
 static const GtkToggleActionEntry toggle_entries_collection[] = {
@@ -1891,7 +1897,7 @@ vnr_window_key_press (GtkWidget *widget, GdkEventKey *event)
                 break;
             } /* else fall-trough is intended */
         case GDK_Up:
-            if (scrollbars_visible (window))
+            if (!uni_scroll_win_image_fits (UNI_SCROLL_WIN (window->scroll_view)))
             {
                 /* break to let scrollview handle the key */
                 break;
@@ -1911,7 +1917,7 @@ vnr_window_key_press (GtkWidget *widget, GdkEventKey *event)
                 break;
             } /* else fall-trough is intended */
         case GDK_Down:
-            if (scrollbars_visible (window))
+            if (!uni_scroll_win_image_fits (UNI_SCROLL_WIN (window->scroll_view)))
             {
                 /* break to let scrollview handle the key */
                 break;
@@ -2243,7 +2249,7 @@ vnr_window_init (VnrWindow * window)
         gtk_widget_hide (window->toolbar);
     else
         gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), TRUE);
-        
+
     // Apply auto-resize preference
     action = gtk_action_group_get_action (window->actions_image,
                                           "ViewResizeWindow");
@@ -2259,6 +2265,13 @@ vnr_window_init (VnrWindow * window)
     window->view = uni_anim_view_new ();
     gtk_widget_set_can_focus(window->view, TRUE);
     window->scroll_view = uni_scroll_win_new (UNI_IMAGE_VIEW (window->view));
+
+    // Apply scrollbar preference
+    action = gtk_action_group_get_action (window->actions_bars,
+                                          "ViewScrollbar");
+    uni_scroll_win_set_show_scrollbar (UNI_SCROLL_WIN (window->scroll_view), window->prefs->show_scrollbar);
+    gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), window->prefs->show_scrollbar);
+
     gtk_box_pack_end (GTK_BOX (window->layout), window->scroll_view, TRUE,TRUE,0);
     gtk_widget_show_all(GTK_WIDGET (window->scroll_view));
 


### PR DESCRIPTION
This PR adds an option to hide the scrollbars.

I personally prefer them hidden, to get as much screen space for the image as possible. Scrolling the image with the keyboard or mouse will still work when the scrollbars are hidden.

The default is to show the scrollbars (so no change from the current behaviour).