### PR TITLE
Load slideshow timeout on window init

### DIFF
--- a/src/vnr-window.c
+++ b/src/vnr-window.c
@@ -2306,6 +2306,9 @@ vnr_window_init (VnrWindow * window)
 
     gtk_widget_grab_focus(window->view);
 
+    // Initialize slideshow timeout
+    window->ss_timeout = window->prefs->slideshow_timeout;
+
     /* Care for Properties dialog */
     window->props_dlg = vnr_properties_dialog_new(window,
                              gtk_action_group_get_action (window->actions_collection,


### PR DESCRIPTION
Puts the correct value inside the window, fixes #30