### PR TITLE
Don't allow drag and drop if source is the viewer itself

### DIFF
--- a/src/vnr-window.c
+++ b/src/vnr-window.c
@@ -2062,6 +2062,9 @@ vnr_window_drag_data_received (GtkWidget *widget,
     if (!gtk_targets_include_uri (&target, 1))
         return;
 
+    if (gtk_drag_get_source_widget (context))
+        return;
+
     suggested_action = gdk_drag_context_get_suggested_action (context);
     if (suggested_action == GDK_ACTION_COPY || suggested_action == GDK_ACTION_ASK)
     {


### PR DESCRIPTION
There's a bug with drag and drop where a user can drag an image from Viewnior and drop it in into the same instance of Viewnior. 

This becomes a problem when the user selects a few images from a folder that contains many and opens them with Viewnior. When navigating through the images, the user will only see the ones he selected. This is alright, but if he accidentally tries to move the image while it's not zoomed in, this will trigger a drag and drop. This will change the number of images the user is browsing from his initial selection to all the images that are inside the folder where this image is. 

This code change in this PR fixes this issue by not updating the list of images to browse if the drag and drop was triggered from inside the application. 

`gtk_drag_get_source_widget` returns `NULL` if the source of the drag is **not** occurring within a single application. Viewnior can still be used to drag and drop images into GIMP after this change for example. 