### PR TITLE
Adding hideable statusbar, which shows the same info as the titlebar

### DIFF
--- a/src/vnr-prefs.c
+++ b/src/vnr-prefs.c
@@ -164,6 +164,7 @@ vnr_prefs_set_default(VnrPrefs *prefs)
     prefs->show_menu_bar = FALSE;
     prefs->show_toolbar = TRUE;
     prefs->show_scrollbar = TRUE;
+    prefs->show_statusbar = FALSE;
     prefs->start_maximized = FALSE;
     prefs->start_slideshow = FALSE;
     prefs->start_fullscreen = FALSE;
@@ -365,6 +366,7 @@ vnr_prefs_load (VnrPrefs *prefs)
     prefs->show_menu_bar = g_key_file_get_boolean (conf, "prefs", "show-menu-bar", &error);
     prefs->show_toolbar = g_key_file_get_boolean (conf, "prefs", "show-toolbar", &error);
     prefs->show_scrollbar = g_key_file_get_boolean (conf, "prefs", "show-scrollbar", &error);
+    prefs->show_statusbar = g_key_file_get_boolean (conf, "prefs", "show-statusbar", &error);
     prefs->start_maximized = g_key_file_get_boolean (conf, "prefs", "start-maximized", &error);
     prefs->slideshow_timeout = g_key_file_get_integer (conf, "prefs", "slideshow-timeout", &error);
     prefs->auto_resize = g_key_file_get_boolean (conf, "prefs", "auto-resize", &error);
@@ -455,6 +457,7 @@ vnr_prefs_save (VnrPrefs *prefs)
     g_key_file_set_boolean (conf, "prefs", "show-menu-bar", prefs->show_menu_bar);
     g_key_file_set_boolean (conf, "prefs", "show-toolbar", prefs->show_toolbar);
     g_key_file_set_boolean (conf, "prefs", "show-scrollbar", prefs->show_scrollbar);
+    g_key_file_set_boolean (conf, "prefs", "show-statusbar", prefs->show_statusbar);
     g_key_file_set_boolean (conf, "prefs", "start-maximized", prefs->start_maximized);
     g_key_file_set_integer (conf, "prefs", "slideshow-timeout", prefs->slideshow_timeout);
     g_key_file_set_boolean (conf, "prefs", "auto-resize", prefs->auto_resize);
@@ -510,6 +513,16 @@ vnr_prefs_set_show_scrollbar (VnrPrefs *prefs, gboolean show_scrollbar)
     if(prefs->show_scrollbar != show_scrollbar)
     {
         prefs->show_scrollbar = show_scrollbar;
+        vnr_prefs_save(prefs);
+    }
+}
+
+void
+vnr_prefs_set_show_statusbar (VnrPrefs *prefs, gboolean show_statusbar)
+{
+    if(prefs->show_statusbar != show_statusbar)
+    {
+        prefs->show_statusbar = show_statusbar;
         vnr_prefs_save(prefs);
     }
 }

--- a/src/vnr-prefs.h
+++ b/src/vnr-prefs.h
@@ -96,6 +96,7 @@ struct _VnrPrefs {
     gboolean show_menu_bar;
     gboolean show_toolbar;
     gboolean show_scrollbar;
+    gboolean show_statusbar;
     gboolean start_maximized;
     gboolean start_slideshow;
     gboolean start_fullscreen;
@@ -118,10 +119,11 @@ GType     vnr_prefs_get_type (void) G_GNUC_CONST;
 
 GObject*  vnr_prefs_new (GtkWidget *window);
 void      vnr_prefs_show_dialog (VnrPrefs *prefs);
-void      vnr_prefs_set_slideshow_timeout   (VnrPrefs *prefs, int value);
-void      vnr_prefs_set_show_menu_bar   (VnrPrefs *prefs, gboolean show_menu_bar);
-void      vnr_prefs_set_show_toolbar    (VnrPrefs *prefs, gboolean show_toolbar);
+void      vnr_prefs_set_slideshow_timeout (VnrPrefs *prefs, int value);
+void      vnr_prefs_set_show_menu_bar     (VnrPrefs *prefs, gboolean show_menu_bar);
+void      vnr_prefs_set_show_toolbar      (VnrPrefs *prefs, gboolean show_toolbar);
 void      vnr_prefs_set_show_scrollbar    (VnrPrefs *prefs, gboolean show_scollbar);
+void      vnr_prefs_set_show_statusbar    (VnrPrefs *prefs, gboolean show_statusbar);
 gboolean  vnr_prefs_save (VnrPrefs *prefs);
 
 G_END_DECLS

--- a/src/vnr-window.c
+++ b/src/vnr-window.c
@@ -87,6 +87,7 @@ const gchar *ui_definition = "<ui>"
       "<menuitem action=\"ViewMenuBar\"/>"
       "<menuitem action=\"ViewToolbar\"/>"
       "<menuitem action=\"ViewScrollbar\"/>"
+      "<menuitem action=\"ViewStatusbar\"/>"
       "<separator/>"
       "<menuitem action=\"ViewZoomIn\"/>"
       "<menuitem action=\"ViewZoomOut\"/>"
@@ -143,6 +144,7 @@ const gchar *ui_definition = "<ui>"
       "<menuitem action=\"ViewMenuBar\"/>"
       "<menuitem action=\"ViewToolbar\"/>"
       "<menuitem action=\"ViewScrollbar\"/>"
+      "<menuitem action=\"ViewStatusbar\"/>"
       "<menuitem name=\"Fullscreen\" action=\"ViewFullscreen\"/>"
       "<menuitem name=\"Slideshow\" action=\"ViewSlideshow\"/>"
       "<separator/>"
@@ -194,6 +196,7 @@ const gchar *ui_definition = "<ui>"
     "<menuitem name=\"MenuBar\" action=\"ViewMenuBar\"/>"
     "<menuitem name=\"Toolbar\" action=\"ViewToolbar\"/>"
     "<menuitem name=\"Scrollbar\" action=\"ViewScrollbar\"/>"
+    "<menuitem name=\"Statusbar\" action=\"ViewStatusbar\"/>"
     "<menuitem name=\"Fullscreen\" action=\"ViewFullscreen\"/>"
     "<separator/>"
     "<menuitem action=\"FileProperties\"/>"
@@ -532,6 +535,7 @@ vnr_window_fullscreen(VnrWindow *window)
 
     update_fs_filename_label(window);
     gtk_widget_hide (window->toolbar);
+    gtk_widget_hide (window->statusbar);
 
     if (window->prefs->show_menu_bar)
         gtk_widget_show (window->properties_button);
@@ -597,6 +601,11 @@ vnr_window_unfullscreen(VnrWindow *window)
         gtk_widget_hide (window->toolbar);
     else
         gtk_widget_show (window->toolbar);
+
+    if(!window->prefs->show_statusbar)
+        gtk_widget_hide (window->statusbar);
+    else
+        gtk_widget_show (window->statusbar);
 
     g_signal_handlers_disconnect_by_func(window->view,
                                          G_CALLBACK(fullscreen_motion_cb),
@@ -861,7 +870,7 @@ fullscreen_motion_cb(GtkWidget * widget, GdkEventMotion * ev, VnrWindow *window)
     if(window->disable_autohide)
         return FALSE;
 
-    /* Show the toolbar only when the moves moves to the top
+    /* Show the toolbar only when the mouse moves to the top
      * of the UniImageView */
     if (ev->y < 20 && !gtk_widget_get_visible (window->toolbar))
         gtk_widget_show (GTK_WIDGET (window->toolbar));
@@ -1111,6 +1120,11 @@ zoom_changed_cb (UniImageView *view, VnrWindow *window)
                                (int)(view->zoom*100.));
 
         gtk_window_set_title (GTK_WINDOW(window), buf);
+
+        gint context_id = gtk_statusbar_get_context_id(GTK_STATUSBAR(window->statusbar), "statusbar");
+        gtk_statusbar_pop (GTK_STATUSBAR(window->statusbar), GPOINTER_TO_INT(context_id));
+        gtk_statusbar_push(GTK_STATUSBAR(window->statusbar), GPOINTER_TO_INT(context_id), buf);
+
         g_free(buf);
     }
 }
@@ -1518,9 +1532,7 @@ vnr_set_wallpaper(GtkAction *action, VnrWindow *win)
 static void
 vnr_window_cmd_fullscreen (GtkAction *action, VnrWindow *window)
 {
-    gboolean fullscreen;
-
-    fullscreen = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+    gboolean fullscreen = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
 
     if (fullscreen)
         vnr_window_fullscreen (window);
@@ -1531,12 +1543,10 @@ vnr_window_cmd_fullscreen (GtkAction *action, VnrWindow *window)
 static void
 vnr_window_cmd_menu_bar (GtkAction *action, VnrWindow *window)
 {
-    gboolean show;
-
-    show = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+    gboolean show = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
     vnr_prefs_set_show_menu_bar(window->prefs, show);
 
-    if(window->mode != VNR_WINDOW_MODE_NORMAL)
+    if (window->mode != VNR_WINDOW_MODE_NORMAL)
        return;
 
 
@@ -1555,9 +1565,7 @@ vnr_window_cmd_menu_bar (GtkAction *action, VnrWindow *window)
 static void
 vnr_window_cmd_toolbar (GtkAction *action, VnrWindow *window)
 {
-    gboolean show;
-
-    show = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+    gboolean show = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
     vnr_prefs_set_show_toolbar(window->prefs, show);
 
     if (show)
@@ -1569,11 +1577,21 @@ vnr_window_cmd_toolbar (GtkAction *action, VnrWindow *window)
 static void
 vnr_window_cmd_scrollbar (GtkAction *action, VnrWindow *window)
 {
-    gboolean show;
-
-    show = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+    gboolean show = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
     vnr_prefs_set_show_scrollbar (window->prefs, show);
     uni_scroll_win_set_show_scrollbar (UNI_SCROLL_WIN (window->scroll_view), show);
+}
+
+static void
+vnr_window_cmd_statusbar (GtkAction *action, VnrWindow *window)
+{
+    gboolean show = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+    vnr_prefs_set_show_statusbar(window->prefs, show);
+
+    if (show)
+        gtk_widget_show (window->statusbar);
+    else
+        gtk_widget_hide (window->statusbar);
 }
 
 static void
@@ -1921,6 +1939,9 @@ static const GtkToggleActionEntry toggle_entries_window[] = {
     { "ViewScrollbar", NULL, N_("Scrollbar"), NULL,
       N_("Show Scrollbar"),
       G_CALLBACK (vnr_window_cmd_scrollbar) },
+    { "ViewStatusbar", NULL, N_("Statusbar"), NULL,
+      N_("Show Statusbar"),
+      G_CALLBACK (vnr_window_cmd_statusbar) },
 };
 
 static const GtkToggleActionEntry toggle_entries_collection[] = {
@@ -2335,6 +2356,20 @@ vnr_window_init (VnrWindow * window)
     window->view = uni_anim_view_new ();
     gtk_widget_set_can_focus(window->view, TRUE);
     window->scroll_view = uni_scroll_win_new (UNI_IMAGE_VIEW (window->view));
+
+
+    window->statusbar = gtk_statusbar_new();
+    gtk_statusbar_set_has_resize_grip(GTK_STATUSBAR(window->statusbar), FALSE);
+    gtk_box_pack_end (GTK_BOX (window->layout), window->statusbar, FALSE,FALSE,0);
+
+    // Apply statusbar preference
+    action = gtk_action_group_get_action (window->actions_bars,
+                                          "ViewStatusbar");
+    if(!window->prefs->show_statusbar)
+        gtk_widget_hide (window->statusbar);
+    else
+        gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), TRUE);
+
 
     // Apply scrollbar preference
     action = gtk_action_group_get_action (window->actions_bars,

--- a/src/vnr-window.h
+++ b/src/vnr-window.h
@@ -65,6 +65,7 @@ struct _VnrWindow {
     GtkWidget *menu_bar;
     GtkWidget *button_menu;
     GtkWidget *toolbar;
+    GtkWidget *statusbar;
     GtkWidget *properties_button;
     GtkWidget *popup_menu;
 


### PR DESCRIPTION
Adds a statusbar at the bottom of the application. Just like the menubar and toolbar, it's hideable (and does not show by default). It displays the same information as the window title bar.

This is useful in window managers that does not show window title bars, such as i3.

Closes #67 and Closes #31 