### PR TITLE
Adding Comments, Image description and Modified time to properties dialog

### DIFF
--- a/src/uni-exiv2.hpp
+++ b/src/uni-exiv2.hpp
@@ -56,7 +56,9 @@ extern "C" {
         { "Exif.Photo.Flash", _("Flash"), NULL },
         { "Exif.Photo.MeteringMode", _("Metering mode"), Exiv2::meteringMode },
         { "Exif.Image.FocalLength", _("Focal length"), Exiv2::focalLength },
-        { "Exif.Image.Software", _("Software"), NULL }
+        { "Exif.Image.Software", _("Software"), NULL },
+        { "Exif.Image.ImageDescription", _("Image description"), NULL },
+        { "Exif.Photo.UserComment", _("User comment"), NULL }
     };
 
     IptcDataDictionary iptcDataDictionary[] = {

--- a/src/vnr-file.c
+++ b/src/vnr-file.c
@@ -139,7 +139,8 @@ vnr_file_dir_content_to_list(gchar *path, gboolean sort, gboolean include_hidden
     f_enum = g_file_enumerate_children(file, G_FILE_ATTRIBUTE_STANDARD_NAME","
                                        G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME","
                                        G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE","
-                                       G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN,
+                                       G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN","
+                                       G_FILE_ATTRIBUTE_TIME_MODIFIED,
                                        G_FILE_QUERY_INFO_NONE,
                                        NULL, NULL);
     file_info = g_file_enumerator_next_file(f_enum,NULL,NULL);
@@ -152,6 +153,8 @@ vnr_file_dir_content_to_list(gchar *path, gboolean sort, gboolean include_hidden
 
         if(vnr_file_is_supported_mime_type(mimetype) && (include_hidden || !g_file_info_get_is_hidden (file_info)) ){
             vnr_file_set_display_name(vnr_file, (char*)g_file_info_get_display_name (file_info));
+
+            vnr_file->mtime = g_file_info_get_attribute_uint64 (file_info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
 
             vnr_file->path =g_strjoin(G_DIR_SEPARATOR_S, path,
                                       vnr_file->display_name, NULL);
@@ -238,7 +241,8 @@ vnr_file_load_uri_list (GSList *uri_list, GList **file_list, gboolean include_hi
         GFileInfo *fileinfo = g_file_query_info (file, G_FILE_ATTRIBUTE_STANDARD_TYPE","
                                       G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME","
                                       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE","
-                                      G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN,
+                                      G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN","
+                                       G_FILE_ATTRIBUTE_TIME_MODIFIED,
                                       0, NULL, error);
 
         if (fileinfo == NULL)
@@ -268,6 +272,8 @@ vnr_file_load_uri_list (GSList *uri_list, GList **file_list, gboolean include_hi
             if(vnr_file_is_supported_mime_type(mimetype) && (include_hidden || !g_file_info_get_is_hidden (fileinfo)) )
             {
                 vnr_file_set_display_name(new_vnrfile, (char*)g_file_info_get_display_name (fileinfo));
+
+                new_vnrfile->mtime = g_file_info_get_attribute_uint64 (fileinfo, G_FILE_ATTRIBUTE_TIME_MODIFIED);
 
                 new_vnrfile->path = p_path;
 

--- a/src/vnr-file.h
+++ b/src/vnr-file.h
@@ -40,6 +40,7 @@ struct _VnrFile {
     const gchar *display_name;
     const gchar *display_name_collate;
     const gchar *path;
+    time_t mtime;
 };
 
 struct _VnrFileClass {

--- a/src/vnr-properties-dialog.c
+++ b/src/vnr-properties-dialog.c
@@ -317,7 +317,7 @@ vnr_properties_dialog_clear_metadata(VnrPropertiesDialog *dialog)
     g_list_free(children);
 }
 
-static void 
+static void
 vnr_cb_add_metadata(const char *label, const char *value, void *user_data) {
     VnrPropertiesDialog *dialog = VNR_PROPERTIES_DIALOG(user_data);
     GtkWidget *temp_label;
@@ -350,8 +350,8 @@ vnr_properties_dialog_update_metadata(VnrPropertiesDialog *dialog)
     vnr_properties_dialog_clear_metadata(dialog);
 
     uni_read_exiv2_map(
-        VNR_FILE(dialog->vnr_win->file_list->data)->path, 
-        vnr_cb_add_metadata, 
+        VNR_FILE(dialog->vnr_win->file_list->data)->path,
+        vnr_cb_add_metadata,
         (void*)dialog);
 }
 
@@ -372,7 +372,7 @@ vnr_properties_dialog_update_image(VnrPropertiesDialog *dialog)
     gchar *width_str, *height_str, *modified_str;
 
     struct stat filestat;
-    stat((gchar*)VNR_FILE(dialog->vnr_win->tree->data)->path, &filestat);
+    stat((gchar*)VNR_FILE(dialog->vnr_win->file_list->data)->path, &filestat);
     int bufsize = 80;
     char buffer[bufsize];
     vnr_get_modified_time(filestat, buffer, bufsize);

--- a/src/vnr-properties-dialog.h
+++ b/src/vnr-properties-dialog.h
@@ -54,12 +54,13 @@ struct _VnrPropertiesDialog {
     GtkWidget* next_button;
     GtkWidget* prev_button;
 
+    GtkWidget* location_label;
     GtkWidget* name_label;
+    GtkWidget* type_label;
     GtkWidget* size_label;
     GtkWidget* width_label;
     GtkWidget* height_label;
-    GtkWidget* type_label;
-    GtkWidget* location_label;
+    GtkWidget* modified_label;
 
     GdkPixbuf *thumbnail;
 


### PR DESCRIPTION
Extends the fields in the Properties dialog.

Will now show
* Date and time when the file was modified
* JPEG comment
* Exif.Image.ImageDescription
* Exif.Photo.UserComment

Inspired by https://github.com/hellosiyan/Viewnior/pull/14

Closes #51