### PR TITLE
Fix include guards in vnr-tools

### DIFF
--- a/src/vnr-tools.c
+++ b/src/vnr-tools.c
@@ -17,9 +17,6 @@
  * along with Viewnior.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __VNR_IMAGE_H__
-#define __VNR_IMAGE_H__
-
 #include <glib.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>
@@ -209,4 +206,3 @@ vnr_tools_apply_embedded_orientation (GdkPixbufAnimation **anim)
 
     *anim = GDK_PIXBUF_ANIMATION(s_anim);
 }
-#endif /* __VNR_IMAGE_H__ */

--- a/src/vnr-tools.h
+++ b/src/vnr-tools.h
@@ -17,8 +17,8 @@
  * along with Viewnior.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __VNR_IMAGE_H__
-#define __VNR_IMAGE_H__
+#ifndef __VNR_TOOLS_H__
+#define __VNR_TOOLS_H__
 
 void    vnr_tools_fit_to_size (gint * w, gint * h, gint mw, gint mh);
 void    vnr_tools_fit_to_size_double (gdouble * w, gdouble * h, gint mw, gint mh);
@@ -29,4 +29,4 @@ void    vnr_tools_apply_embedded_orientation (GdkPixbufAnimation **anim);
 gint    compare_quarks (gconstpointer a, gconstpointer b);
 void    get_position_of_element_in_list(GList *list, gint *current, gint *total);
 
-#endif /* __VNR_IMAGE_H__ */
+#endif /* __VNR_TOOLS_H__ */


### PR DESCRIPTION
Remove include guards from `vnr-tools.c` and rename `__VNR_IMAGE_H__` to `__VNR_TOOLS_H__` in `vnr-tools.h`.