### PR TITLE
Preparation for porting to GTK3 in GTK+ 2, part 2

### DIFF
--- a/src/uni-cache.c
+++ b/src/uni-cache.c
@@ -210,8 +210,7 @@ uni_pixbuf_draw_cache_scroll_intersection (GdkPixbuf * pixbuf,
  **/
 static void
 uni_pixbuf_draw_cache_intersect_draw (UniPixbufDrawCache * cache,
-                                      UniPixbufDrawOpts * opts,
-                                      GdkDrawable * drawable)
+                                      UniPixbufDrawOpts * opts)
 {
     GdkRectangle this = opts->zoom_rect;
     GdkRectangle old_rect = cache->old.zoom_rect;
@@ -259,14 +258,14 @@ uni_pixbuf_draw_cache_intersect_draw (UniPixbufDrawCache * cache,
  * uni_pixbuf_draw_cache_draw:
  * @cache: a #UniPixbufDrawCache
  * @opts: the #UniPixbufDrawOpts to use in this draw
- * @drawable: a #GdkDrawable to draw on
+ * @window: a #GdkWindow to draw on
  *
  * Redraws the area specified in the pixbuf draw options in an
  * efficient way by using caching.
  **/
 void
 uni_pixbuf_draw_cache_draw (UniPixbufDrawCache * cache,
-                            UniPixbufDrawOpts * opts, GdkDrawable * drawable)
+                            UniPixbufDrawOpts * opts, GdkWindow * window)
 {
     GdkRectangle this = opts->zoom_rect;
     UniPixbufDrawMethod method =
@@ -280,7 +279,7 @@ uni_pixbuf_draw_cache_draw (UniPixbufDrawCache * cache,
     }
     else if (method == UNI_PIXBUF_DRAW_METHOD_SCROLL)
     {
-        uni_pixbuf_draw_cache_intersect_draw (cache, opts, drawable);
+        uni_pixbuf_draw_cache_intersect_draw (cache, opts);
     }
     else if (method == UNI_PIXBUF_DRAW_METHOD_SCALE)
     {
@@ -307,7 +306,7 @@ uni_pixbuf_draw_cache_draw (UniPixbufDrawCache * cache,
                                 (double) -this.x, (double) -this.y,
                                 opts->zoom, opts->interp, this.x, this.y);
     }
-    gdk_draw_pixbuf (drawable,
+    gdk_draw_pixbuf (window,
                      NULL,
                      cache->last_pixbuf,
                      deltax, deltay,

--- a/src/uni-cache.h
+++ b/src/uni-cache.h
@@ -84,7 +84,7 @@ void    uni_pixbuf_draw_cache_free          (UniPixbufDrawCache * cache);
 void    uni_pixbuf_draw_cache_invalidate    (UniPixbufDrawCache * cache);
 void    uni_pixbuf_draw_cache_draw          (UniPixbufDrawCache * cache,
                                              UniPixbufDrawOpts * opts,
-                                             GdkDrawable * drawable);
+                                             GdkWindow * window);
 
 UniPixbufDrawMethod uni_pixbuf_draw_cache_get_method (UniPixbufDrawOpts * old,
                                                       UniPixbufDrawOpts *

--- a/src/uni-dragger.c
+++ b/src/uni-dragger.c
@@ -139,9 +139,9 @@ uni_dragger_pixbuf_changed (UniDragger * tool,
 
 void
 uni_dragger_paint_image (UniDragger * tool,
-                         UniPixbufDrawOpts * opts, GdkDrawable * drawable)
+                         UniPixbufDrawOpts * opts, GdkWindow * window)
 {
-    uni_pixbuf_draw_cache_draw (tool->cache, opts, drawable);
+    uni_pixbuf_draw_cache_draw (tool->cache, opts, window);
 }
 
 /*************************************************************/

--- a/src/uni-dragger.h
+++ b/src/uni-dragger.h
@@ -86,7 +86,7 @@ void    uni_dragger_pixbuf_changed      (UniDragger * tool,
 
 void    uni_dragger_paint_image         (UniDragger * tool,
                                          UniPixbufDrawOpts * opts,
-                                         GdkDrawable * drawable);
+                                         GdkWindow * window);
 
 G_END_DECLS
 #endif /* __UNI_TOOL_DRAGGER_H__ */

--- a/src/uni-image-view.c
+++ b/src/uni-image-view.c
@@ -306,7 +306,7 @@ uni_image_view_repaint_area (UniImageView * view, GdkRectangle * paint_rect)
 static void
 uni_image_view_fast_scroll (UniImageView * view, int delta_x, int delta_y)
 {
-    GdkDrawable *drawable = gtk_widget_get_window (GTK_WIDGET (view));
+    GdkWindow *drawable = gtk_widget_get_window (GTK_WIDGET (view));
 
     int src_x, src_y;
     int dest_x, dest_y;

--- a/src/uni-image-view.c
+++ b/src/uni-image-view.c
@@ -570,9 +570,7 @@ uni_image_view_button_press (GtkWidget * widget, GdkEventButton * ev)
     }
     else if(ev->type == GDK_2BUTTON_PRESS && ev->button == 1 && vnr_win->prefs->behavior_click == VNR_PREFS_CLICK_NEXT)
     {
-
-        int width;
-        gdk_drawable_get_size(GDK_DRAWABLE(gtk_widget_get_window(widget)), &width, NULL);
+        int width = gdk_window_get_width(gtk_widget_get_window(widget));
 
         if(ev->x/width < 0.5)
             vnr_window_prev(vnr_win);

--- a/src/uni-image-view.c
+++ b/src/uni-image-view.c
@@ -628,7 +628,7 @@ uni_image_view_motion_notify (GtkWidget * widget, GdkEventMotion * ev)
 }
 
 static gboolean
-uni_image_view_hadj_changed_cb (GtkObject * adj, UniImageView * view)
+uni_image_view_hadj_changed_cb (GObject * adj, UniImageView * view)
 {
     int offset_x;
     offset_x = gtk_adjustment_get_value (GTK_ADJUSTMENT (adj));
@@ -637,7 +637,7 @@ uni_image_view_hadj_changed_cb (GtkObject * adj, UniImageView * view)
 }
 
 static gboolean
-uni_image_view_vadj_changed_cb (GtkObject * adj, UniImageView * view)
+uni_image_view_vadj_changed_cb (GObject * adj, UniImageView * view)
 {
     int offset_y;
     offset_y = gtk_adjustment_get_value (GTK_ADJUSTMENT (adj));

--- a/src/uni-utils.c
+++ b/src/uni-utils.c
@@ -64,12 +64,12 @@ uni_pixbuf_scale_blend (GdkPixbuf * src,
  * draw a pixel at position (0,0).
  **/
 void
-uni_draw_rect (GdkDrawable * drawable,
+uni_draw_rect (GdkWindow * window,
                GdkGC * gc, gboolean filled, GdkRectangle * rect)
 {
     if (rect->width <= 0 || rect->height <= 0)
         return;
-    gdk_draw_rectangle (drawable, gc, filled,
+    gdk_draw_rectangle (window, gc, filled,
                         rect->x, rect->y, rect->width - 1, rect->height - 1);
 }
 

--- a/src/uni-utils.h
+++ b/src/uni-utils.h
@@ -46,7 +46,7 @@ void    uni_pixbuf_scale_blend          (GdkPixbuf * src,
                                          gdouble zoom,
                                          GdkInterpType interp, int check_x, int check_y);
 
-void    uni_draw_rect                   (GdkDrawable * drawable,
+void    uni_draw_rect                   (GdkWindow * window,
                                          GdkGC * gc, gboolean filled, GdkRectangle * rect);
 
 void    uni_rectangle_get_rects_around  (GdkRectangle * outer,

--- a/src/vnr-crop.c
+++ b/src/vnr-crop.c
@@ -44,21 +44,18 @@ static gboolean drawable_motion_cb (GtkWidget *widget,
 /***** Private actions ***************************************/
 /*************************************************************/
 static void
-vnr_crop_clear_rectangle(VnrCrop *crop)
+vnr_crop_draw_rectangle(VnrCrop *crop)
 {
     if(crop->do_redraw)
-        gdk_draw_rectangle (GDK_DRAWABLE(gtk_widget_get_window(crop->image)), crop->gc, FALSE,
+        gdk_draw_rectangle (gtk_widget_get_window(crop->image), crop->gc, FALSE,
                             crop->sub_x, crop->sub_y,
                             crop->sub_width, crop->sub_height);
 }
 
-static void
-vnr_crop_draw_rectangle(VnrCrop *crop)
+static inline void
+vnr_crop_clear_rectangle(VnrCrop *crop)
 {
-    if(crop->do_redraw)
-        gdk_draw_rectangle (GDK_DRAWABLE(gtk_widget_get_window(crop->image)), crop->gc, FALSE,
-                            crop->sub_x, crop->sub_y,
-                            crop->sub_width, crop->sub_height);
+    vnr_crop_draw_rectangle (crop);
 }
 
 static void
@@ -266,10 +263,10 @@ static gboolean
 drawable_expose_cb (GtkWidget *widget, GdkEventExpose *event, VnrCrop *crop)
 {
     GdkWindow *window = gtk_widget_get_window(widget);
-    gdk_draw_pixbuf (GDK_DRAWABLE(window), NULL, crop->preview_pixbuf,
+    gdk_draw_pixbuf (window, NULL, crop->preview_pixbuf,
                      0, 0, 0, 0, -1, -1, GDK_RGB_DITHER_NORMAL, 0, 0);
 
-    crop->gc = gdk_gc_new(GDK_DRAWABLE(window));
+    crop->gc = gdk_gc_new(window);
     gdk_gc_set_function (crop->gc, GDK_INVERT);
     gdk_gc_set_line_attributes (crop->gc,
                                 2,

--- a/src/vnr-message-area.c
+++ b/src/vnr-message-area.c
@@ -69,7 +69,7 @@ vnr_message_area_initialize(VnrMessageArea * msg_area)
     gtk_container_add(GTK_CONTAINER(msg_area->button_box),
                       msg_area->cancel_button);
 
-    gtk_widget_hide_all(msg_area->hbox);
+    gtk_widget_hide(msg_area->hbox);
     gtk_widget_set_state(GTK_WIDGET(msg_area), GTK_STATE_SELECTED);
     gtk_widget_set_state(msg_area->button_box, GTK_STATE_NORMAL);
     msg_area->initialized = TRUE;
@@ -132,7 +132,7 @@ vnr_message_area_show (VnrMessageArea *msg_area,
     }
 
     gtk_widget_show_all(GTK_WIDGET (msg_area->hbox));
-    gtk_widget_hide_all(GTK_WIDGET (msg_area->button_box));
+    gtk_widget_hide(GTK_WIDGET (msg_area->button_box));
 }
 
 void
@@ -164,7 +164,7 @@ vnr_message_area_show_with_button (VnrMessageArea *msg_area,
 void
 vnr_message_area_hide (VnrMessageArea *msg_area)
 {
-    gtk_widget_hide_all(GTK_WIDGET (msg_area->hbox));
+    gtk_widget_hide(GTK_WIDGET (msg_area->hbox));
     if(msg_area->with_button)
     {
         g_signal_handlers_disconnect_by_func (msg_area->user_button,

--- a/src/vnr-prefs.c
+++ b/src/vnr-prefs.c
@@ -192,20 +192,20 @@ build_dialog (VnrPrefs *prefs)
     GtkToggleButton *dark_background;
     GtkToggleButton *fit_on_fullscreen;
     GtkBox *zoom_mode_box;
-    GtkComboBox *zoom_mode;
+    GtkComboBoxText *zoom_mode;
     GtkToggleButton *smooth_images;
     GtkToggleButton *confirm_delete;
     GtkToggleButton *reload_on_save;
     GtkSpinButton *slideshow_timeout;
     GtkTable *behavior_table;
-    GtkComboBox *action_wheel;
-    GtkComboBox *action_click;
-    GtkComboBox *action_modify;
+    GtkComboBoxText *action_wheel;
+    GtkComboBoxText *action_click;
+    GtkComboBoxText *action_modify;
     GtkRange *jpeg_scale;
     GtkRange *png_scale;
 
     GtkBox *desktop_box;
-    GtkComboBox *desktop_env;
+    GtkComboBoxText *desktop_env;
 
     builder = gtk_builder_new ();
     gtk_builder_add_from_file (builder, UI_PATH, &error);
@@ -273,12 +273,12 @@ build_dialog (VnrPrefs *prefs)
     /* Zoom mode combo box */
     zoom_mode_box = GTK_BOX (gtk_builder_get_object (builder, "zoom_mode_box"));
 
-    zoom_mode = (GtkComboBox*) gtk_combo_box_new_text();
-    gtk_combo_box_append_text(zoom_mode, _("Smart Mode"));
-    gtk_combo_box_append_text(zoom_mode, _("1:1 Mode"));
-    gtk_combo_box_append_text(zoom_mode, _("Fit To Window Mode"));
-    gtk_combo_box_append_text(zoom_mode, _("Last Used Mode"));
-    gtk_combo_box_set_active(zoom_mode, prefs->zoom);
+    zoom_mode = (GtkComboBoxText*) gtk_combo_box_text_new();
+    gtk_combo_box_text_append_text(zoom_mode, _("Smart Mode"));
+    gtk_combo_box_text_append_text(zoom_mode, _("1:1 Mode"));
+    gtk_combo_box_text_append_text(zoom_mode, _("Fit To Window Mode"));
+    gtk_combo_box_text_append_text(zoom_mode, _("Last Used Mode"));
+    gtk_combo_box_set_active(GTK_COMBO_BOX(zoom_mode), prefs->zoom);
 
     gtk_box_pack_end (zoom_mode_box, GTK_WIDGET(zoom_mode), FALSE, FALSE, 0);
     gtk_widget_show(GTK_WIDGET(zoom_mode));
@@ -288,18 +288,18 @@ build_dialog (VnrPrefs *prefs)
     /* Desktop combo box */
     desktop_box = GTK_BOX (gtk_builder_get_object (builder, "desktop_box"));
 
-    desktop_env = (GtkComboBox*) gtk_combo_box_new_text();
-    gtk_combo_box_append_text(desktop_env, "GNOME 2");
-    gtk_combo_box_append_text(desktop_env, "GNOME 3");
-    gtk_combo_box_append_text(desktop_env, "XFCE");
-    gtk_combo_box_append_text(desktop_env, "LXDE");
-    gtk_combo_box_append_text(desktop_env, "PUPPY");
-    gtk_combo_box_append_text(desktop_env, "FluxBox");
-    gtk_combo_box_append_text(desktop_env, "Nitrogen");
-    gtk_combo_box_append_text(desktop_env, "MATE");
-    gtk_combo_box_append_text(desktop_env, "Cinnamon");
-    gtk_combo_box_append_text(desktop_env, _("Autodetect"));
-    gtk_combo_box_set_active(desktop_env, prefs->desktop);
+    desktop_env = (GtkComboBoxText*) gtk_combo_box_text_new();
+    gtk_combo_box_text_append_text(desktop_env, "GNOME 2");
+    gtk_combo_box_text_append_text(desktop_env, "GNOME 3");
+    gtk_combo_box_text_append_text(desktop_env, "XFCE");
+    gtk_combo_box_text_append_text(desktop_env, "LXDE");
+    gtk_combo_box_text_append_text(desktop_env, "PUPPY");
+    gtk_combo_box_text_append_text(desktop_env, "FluxBox");
+    gtk_combo_box_text_append_text(desktop_env, "Nitrogen");
+    gtk_combo_box_text_append_text(desktop_env, "MATE");
+    gtk_combo_box_text_append_text(desktop_env, "Cinnamon");
+    gtk_combo_box_text_append_text(desktop_env, _("Autodetect"));
+    gtk_combo_box_set_active(GTK_COMBO_BOX(desktop_env), prefs->desktop);
 
     gtk_box_pack_end (desktop_box, GTK_WIDGET(desktop_env), FALSE, FALSE, 0);
     gtk_widget_show(GTK_WIDGET(desktop_env));
@@ -309,31 +309,31 @@ build_dialog (VnrPrefs *prefs)
     /* Behavior combo boxes */
     behavior_table = GTK_TABLE (gtk_builder_get_object (builder, "behavior_table"));
 
-    action_wheel = (GtkComboBox*) gtk_combo_box_new_text();
-    gtk_combo_box_append_text(action_wheel, _("Navigate images"));
-    gtk_combo_box_append_text(action_wheel, _("Zoom image"));
-    gtk_combo_box_append_text(action_wheel, _("Scroll image up/down"));
-    gtk_combo_box_set_active(action_wheel, prefs->behavior_wheel);
+    action_wheel = (GtkComboBoxText*) gtk_combo_box_text_new();
+    gtk_combo_box_text_append_text(action_wheel, _("Navigate images"));
+    gtk_combo_box_text_append_text(action_wheel, _("Zoom image"));
+    gtk_combo_box_text_append_text(action_wheel, _("Scroll image up/down"));
+    gtk_combo_box_set_active(GTK_COMBO_BOX(action_wheel), prefs->behavior_wheel);
 
     gtk_table_attach (behavior_table, GTK_WIDGET(action_wheel), 1,2,0,1, GTK_FILL,0, 0,0);
     gtk_widget_show(GTK_WIDGET(action_wheel));
     g_signal_connect(G_OBJECT(action_wheel), "changed", G_CALLBACK(change_action_wheel_cb), prefs);
 
-    action_click = (GtkComboBox*) gtk_combo_box_new_text();
-    gtk_combo_box_append_text(action_click, _("Switch zoom modes"));
-    gtk_combo_box_append_text(action_click, _("Enter fullscreen mode"));
-    gtk_combo_box_append_text(action_click, _("Navigate images"));
-    gtk_combo_box_set_active(action_click, prefs->behavior_click);
+    action_click = (GtkComboBoxText*) gtk_combo_box_text_new();
+    gtk_combo_box_text_append_text(action_click, _("Switch zoom modes"));
+    gtk_combo_box_text_append_text(action_click, _("Enter fullscreen mode"));
+    gtk_combo_box_text_append_text(action_click, _("Navigate images"));
+    gtk_combo_box_set_active(GTK_COMBO_BOX(action_click), prefs->behavior_click);
 
     gtk_table_attach (behavior_table, GTK_WIDGET(action_click), 1,2,1,2, GTK_FILL,0, 0,0);
     gtk_widget_show(GTK_WIDGET(action_click));
     g_signal_connect(G_OBJECT(action_click), "changed", G_CALLBACK(change_action_click_cb), prefs);
 
-    action_modify = (GtkComboBox*) gtk_combo_box_new_text();
-    gtk_combo_box_append_text(action_modify, _("Ask every time"));
-    gtk_combo_box_append_text(action_modify, _("Autosave"));
-    gtk_combo_box_append_text(action_modify, _("Ignore changes"));
-    gtk_combo_box_set_active(action_modify, prefs->behavior_modify);
+    action_modify = (GtkComboBoxText*) gtk_combo_box_text_new();
+    gtk_combo_box_text_append_text(action_modify, _("Ask every time"));
+    gtk_combo_box_text_append_text(action_modify, _("Autosave"));
+    gtk_combo_box_text_append_text(action_modify, _("Ignore changes"));
+    gtk_combo_box_set_active(GTK_COMBO_BOX(action_modify), prefs->behavior_modify);
 
     gtk_table_attach (behavior_table, GTK_WIDGET(action_modify), 1,2,2,3, GTK_FILL,0, 0,0);
     gtk_widget_show(GTK_WIDGET(action_modify));

--- a/src/vnr-window.c
+++ b/src/vnr-window.c
@@ -1096,10 +1096,10 @@ window_change_state_cb (GtkWidget * widget, GdkEventWindowState * event, gpointe
 
 
 static void
-window_destroy_cb (GtkObject *object, gpointer user_data)
+window_destroy_cb (GtkWidget *widget, gpointer user_data)
 {
     vnr_window_save_accel_map();
-    vnr_prefs_save(VNR_WINDOW(object)->prefs);
+    vnr_prefs_save(VNR_WINDOW(widget)->prefs);
     gtk_main_quit();
 }
 


### PR DESCRIPTION
* Replace deprecated functions
* Replace removed in GTK3 `GdkDrawable` and `GtkObject`