### PR TITLE
Fix build with >=exiv2-0.28.0, raise minimum to 0.27.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ viewnior_deps = [
   dependency('gio-2.0', version: glib_ver),
   dependency('shared-mime-info', version: '>= 0.20'),
   dependency('gdk-pixbuf-2.0', version: '>= 0.21'),
-  dependency('exiv2', version: '>= 0.21'),
+  dependency('exiv2', version: '>= 0.27'),
 ]
 #
 


### PR DESCRIPTION
- enables use of EXIV2_TEST_VERSION macro
- add compatibility for exiv2-0.28.0

(alternative take)